### PR TITLE
【サーバサイド】商品詳細表示 from 2020 10 15

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -75,7 +75,7 @@ class ItemsController < ApplicationController
   private
 
   def item_params
-    params.require(:item).permit(:images, :name, :description, :category, :brand, :condition, :shipment_fee_id, :shipment_region_id, :shipment_schedule_id, :price, :category_id,[images_attributes: [:src]]).merge(user_id: current_user.id)
+    params.require(:item).permit(:images, :name, :description, :category, :brand, :condition_id, :shipment_fee_id, :shipment_region_id, :shipment_schedule_id, :price, :category_id,[images_attributes: [:src]]).merge(user_id: current_user.id)
   end
 
   def set_item

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -1,0 +1,6 @@
+class Condition < ActiveHash::Base
+  self.data = [
+      {id: 0, name: '選択してください'},
+      {id: 1, name: "新品"}, {id: 2, name: "未使用に近い"}, {id: 3, name: "目立った傷や汚れなし"}, {id: 4, name: "やや傷や汚れあり"}
+  ]
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,12 +1,14 @@
 class Item < ApplicationRecord
-  validates :user_id,:images,:name,:description,:category,:condition,:shipment_fee_id,:shipment_region_id,:shipment_schedule_id,:price,presence: true
+  validates :user_id,:images,:name,:description,:category,:condition_id,:shipment_fee_id,:shipment_region_id,:shipment_schedule_id,:price, presence: true
   validates :images, presence: true
   validates :name, presence: true, length: { maximum: 40 }
   validates :description, presence: true, length: { maximum: 1000 }
-  validates :condition, numericality:{other_than: 0, message: "「選択してください」以外を選択してください"}
+  # validates :condition, numericality:{other_than: 0, message: "「選択してください」以外を選択してください"}
   extend ActiveHash::Associations::ActiveRecordExtensions
     belongs_to :user, class_name: "User"
 
+    belongs_to_active_hash :condition
+    validates :condition_id, numericality:{other_than: 0, message: "「選択してください」以外を選択してください"}
     belongs_to_active_hash :shipment_fee
     validates :shipment_fee_id, numericality:{other_than: 0, message: "「選択してください」以外を選択してください"}
     belongs_to_active_hash :shipment_region

--- a/app/models/shipment_fee.rb
+++ b/app/models/shipment_fee.rb
@@ -1,6 +1,6 @@
 class ShipmentFee < ActiveHash::Base
   self.data = [
       {id: 0, name: '選択してください'},
-      {id: 1, name: '送料込み（出品者負担)'}, {id: 2, name: '着払い（購入者負担'}
+      {id: 1, name: '送料込み（出品者負担)'}, {id: 2, name: '着払い（購入者負担）'}
   ]
 end

--- a/app/views/items/_form.html.haml
+++ b/app/views/items/_form.html.haml
@@ -71,7 +71,8 @@
                 .content__detail_condition--title
                   %label 商品の状態
                   %span 必須
-                = f.select :condition, [["選択してください", 0],["新品", 1],["未使用に近い", 2],["目立った傷や汚れなし", 3],["やや傷や汚れあり", 4]], {},class: "content__detail_condition--select"
+                -# = f.select :condition, [["選択してください", 0],["新品", 1],["未使用に近い", 2],["目立った傷や汚れなし", 3],["やや傷や汚れあり", 4]], {},class: "content__detail_condition--select"
+                = f.collection_select :condition_id, Condition.all, :id, :name, {}, class: "content__detail_condition--select"
                 %p.detail_condition_note
         .formNew__shipment
           .formNew__shipment--content

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -106,6 +106,8 @@
               = link_to '編集の編集', "#", method: :get, class: "editbox__link", style: "display: inline-block; color: #ffffff; font-size: 14px; height: 50px; width: 100%; line-height: 50px; text-align: center; background-color: #ea352d; border-radius: 10px;"
             .deletebox
               = link_to 'この商品を削除する', item_path(@item.id), method: :delete, class: "deletebox__link", style: "display: inline-block; color: #ffffff; font-size: 14px; margin-top:20px; height: 50px; width: 100%; line-height: 50px; text-align: center; background-color: #aaaaaa; border-radius: 10px;"
+        - elsif user_signed_in? && current_user.id != @item.user_id
+          = link_to '購入画面に進む', new_item_payment_path(@item.id), method: :get, class: "paymentbox__link", style: "display: inline-block; color: #ffffff; font-size: 14px; margin-top:20px; height: 50px; width: 100%; line-height: 50px; text-align: center; background-color: #ea352d; border-radius: 10px;"
         .commentbox
           %div.commentcontents
           %form#new_comment.new_comment{"accept-charset" => "UTF-8", action: "#", method: "post"}

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -56,7 +56,8 @@
               %tbody
                 %tr
                   %th{style:"width: 152px; background-color: #eee; font-weight: 400; padding: 8px; border: 1px solid #dedede; font-size: 14px; text-align: center;"} 出品者
-                  %td{style:"width: 467px; padding: 15px 15px; border: 1px solid #dedede; font-size: 14px;"} hoge
+                  %td{style:"width: 467px; padding: 15px 15px; border: 1px solid #dedede; font-size: 14px;"}
+                    = @item.user.nickname
                 %tr
                   %th{style:"width: 152px; background-color: #eee; font-weight: 400; padding: 8px; border: 1px solid #dedede; font-size: 14px; text-align: center;"} カテゴリー
                   %td{style:"width: 467px; padding: 15px 15px; border: 1px solid #dedede; font-size: 14px;"}
@@ -67,10 +68,6 @@
                     %link_to{href: "#",style:"color: #3ccace;"} アウター
                 %tr
                   %th{style:"width: 152px; background-color: #eee; font-weight: 400; padding: 8px; border: 1px solid #dedede; font-size: 14px; text-align: center;"} ブランド
-                  %td{style:"width: 467px; padding: 15px 15px; border: 1px solid #dedede; font-size: 14px;"}
-                    = @item.user.nickname
-                %tr
-                  %th{style:"width: 152px; background-color: #eee; font-weight: 400; padding: 8px; border: 1px solid #dedede; font-size: 14px; text-align: center;"}  商品のサイズ
                   %td{style:"width: 467px; padding: 15px 15px; border: 1px solid #dedede; font-size: 14px;"}
                     = @item.brand
                 %tr

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -30,7 +30,8 @@
     .contentright
       .topcontent
         .itembox
-          %div.itembox__name product3
+          %div.itembox__name
+            = @item.name
           .itembox__body
             %div
               %div
@@ -44,13 +45,15 @@
                     %img{src: "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/15/a003.png",style: "height: 87px; width: 140px; object-fit: cover; margin-left: 5px;"}/
           .itembox__price
             .itembox__price-price
-              ¥30000
+              = @item.price
+              %span 円
             .itembox__price-detail
               %span
                 (税込)
               %span
                 送料込み
-          .itemdetail 親譲りの無鉄砲で小供の時から損ばかりしている。小学校に居る時分学校の二階から飛び降りて一週間ほど腰を抜かした事がある。なぜそんな無闇をしたと聞く人があるかも知れぬ。別段深い理由でもない。新築の二階から首を出していたら、同級生の一人が冗談に、いくら威張っても、そこから飛び降りる事は出来まい。弱虫やーい。と囃したからである。小使に負ぶさって帰って来た時、おやじが大きな眼をして二階ぐらいから飛び降りて腰
+          .itemdetail
+            = @item.description
           .table
             %table{border: "1"}
               %tbody
@@ -68,22 +71,28 @@
                 %tr
                   %th{style:"width: 152px; background-color: #eee; font-weight: 400; padding: 8px; border: 1px solid #dedede; font-size: 14px; text-align: center;"} ブランド
                   %td{style:"width: 467px; padding: 15px 15px; border: 1px solid #dedede; font-size: 14px;"}
+                    = @item.user.nickname
                 %tr
                   %th{style:"width: 152px; background-color: #eee; font-weight: 400; padding: 8px; border: 1px solid #dedede; font-size: 14px; text-align: center;"}  商品のサイズ
                   %td{style:"width: 467px; padding: 15px 15px; border: 1px solid #dedede; font-size: 14px;"}
+                    = @item.brand
                 %tr
                   %th{style:"width: 152px; background-color: #eee; font-weight: 400; padding: 8px; border: 1px solid #dedede; font-size: 14px; text-align: center;"}  商品の状態
-                  %td{style:"width: 467px; padding: 15px 15px; border: 1px solid #dedede; font-size: 14px;"} 未使用に近い
+                  %td{style:"width: 467px; padding: 15px 15px; border: 1px solid #dedede; font-size: 14px;"}
+                    = @item.condition.name
                 %tr
                   %th{style:"width: 152px; background-color: #eee; font-weight: 400; padding: 8px; border: 1px solid #dedede; font-size: 14px; text-align: center;"} 配送料の負担
-                  %td{style:"width: 467px; padding: 15px 15px; border: 1px solid #dedede; font-size: 14px;"} 送料込み（出品者負担）
+                  %td{style:"width: 467px; padding: 15px 15px; border: 1px solid #dedede; font-size: 14px;"}
+                    = @item.shipment_fee.name
                 %tr
                   %th{style:"width: 152px; background-color: #eee; font-weight: 400; padding: 8px; border: 1px solid #dedede; font-size: 14px; text-align: center;"} 発送元の地域
                   %td{style:"width: 467px; padding: 15px 15px; border: 1px solid #dedede; font-size: 14px;"}
-                    %link_to{href: "#",style:"color: #3ccace;"} 岩手県
+                    %link_to{href: "#",style:"color: #3ccace;"}
+                      = @item.shipment_region.name
                 %tr
                   %th{style:"width: 152px; background-color: #eee; font-weight: 400; padding: 8px; border: 1px solid #dedede; font-size: 14px; text-align: center;"} 発送日の目安
-                  %td{style:"width: 467px; padding: 15px 15px; border: 1px solid #dedede; font-size: 14px;"} 4-7日で発送
+                  %td{style:"width: 467px; padding: 15px 15px; border: 1px solid #dedede; font-size: 14px;"}
+                    = @item.shipment_schedule.name
           .optionalarea
             %div{style: "margin: 10px 0 0;display: flex;"}
               %div#likeBtn.optionalbtn.likebtn{style: "margin-right: auto;padding: 6px 10px;border-radius: 40px;color: #3ccace;border: 1px solid #ffb340;"}

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -35,14 +35,11 @@
           .itembox__body
             %div
               %div
-                %img{src: "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/13/a007.png",style: "height: 346px; width: 100%; object-fit: cover;"}/
+                = image_tag @item.images[0].src.url, style: "height: 346px; width: 100%; object-fit: cover;"
                 %div{style: "display: flex; justify-content: center; margin-top: 10px;"}
-                  %div
-                    %img{src: "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/13/a007.png",style: "height: 87px; width: 140px; object-fit: cover; margin-right: 5px;"}/
-                  %div
-                    %img{src: "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/14/a001.png",style: "height: 87px; width: 140px; object-fit: cover; margin-right: 5px; margin-left: 5px;"}/
-                  %div
-                    %img{src: "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/15/a003.png",style: "height: 87px; width: 140px; object-fit: cover; margin-left: 5px;"}/
+                  - @item.images.each do |image|
+                    %div
+                      = image_tag image.src.url, style: "height: 87px; width: 140px; object-fit: cover; margin-right: 5px;"
           .itembox__price
             .itembox__price-price
               = @item.price

--- a/db/migrate/20200826120849_create_items.rb
+++ b/db/migrate/20200826120849_create_items.rb
@@ -2,17 +2,17 @@ class CreateItems < ActiveRecord::Migration[5.2]
   def change
     create_table :items do |t|
 #       t.references :user, foreign_key: { to_table: :users }
-      t.references :category, foreign_key: true
-      t.references :user,foreign_key: true
-      t.references :buyer, foreign_key: { to_table: :users }
-      t.string :name, null: false, default: ""
-      t.string :description, null: false, default: ""
-      t.string :brand
-      t.string :condition, null: false, default: ""
-      t.integer :shipment_fee_id, null: false, default: 0
-      t.integer :shipment_region_id,  null: false, default: 0
-      t.integer :shipment_schedule_id,  null: false, default: 0
-      t.integer :price, null: false, default: nil
+      t.references :category,                                        foreign_key: true
+      t.references :user,                                            foreign_key: true
+      t.references :buyer,                                           foreign_key: { to_table: :users }
+      t.string     :name,                  null: false, default: ""
+      t.string     :description,           null: false, default: ""
+      t.string     :brand
+      t.string     :condition,             null: false, default: ""
+      t.integer    :shipment_fee_id,       null: false, default: 0
+      t.integer    :shipment_region_id,    null: false, default: 0
+      t.integer    :shipment_schedule_id,  null: false, default: 0
+      t.integer    :price,                 null: false, default: nil
 
       t.timestamps
     end

--- a/db/migrate/20200826120849_create_items.rb
+++ b/db/migrate/20200826120849_create_items.rb
@@ -8,7 +8,7 @@ class CreateItems < ActiveRecord::Migration[5.2]
       t.string     :name,                  null: false, default: ""
       t.string     :description,           null: false, default: ""
       t.string     :brand
-      t.string     :condition,             null: false, default: ""
+      t.integer    :condition_id,          null: false, default: 0
       t.integer    :shipment_fee_id,       null: false, default: 0
       t.integer    :shipment_region_id,    null: false, default: 0
       t.integer    :shipment_schedule_id,  null: false, default: 0

--- a/db/migrate/20200922080904_create_images.rb
+++ b/db/migrate/20200922080904_create_images.rb
@@ -2,7 +2,7 @@ class CreateImages < ActiveRecord::Migration[5.2]
   def change
     create_table :images do |t|
       t.string :src
-      t.references :item, foreign_key: true
+      t.references :item
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -60,7 +60,7 @@ ActiveRecord::Schema.define(version: 2020_10_05_073746) do
     t.string "name", default: "", null: false
     t.string "description", default: "", null: false
     t.string "brand"
-    t.string "condition", default: "", null: false
+    t.integer "condition_id", default: 0, null: false
     t.integer "shipment_fee_id", default: 0, null: false
     t.integer "shipment_region_id", default: 0, null: false
     t.integer "shipment_schedule_id", default: 0, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -91,7 +91,6 @@ ActiveRecord::Schema.define(version: 2020_10_05_073746) do
   end
 
   add_foreign_key "cards", "users"
-  add_foreign_key "images", "items"
   add_foreign_key "items", "categories"
   add_foreign_key "items", "users"
   add_foreign_key "items", "users", column: "buyer_id"


### PR DESCRIPTION
### What
#### 出品された商品の詳細情報の表示
#### 出品者とログイン中ユーザーが一致：編集＆削除リンクを表示
#### 出品者とログイン中ユーザーが不一致：購入確認リンクを表示


### Why
#### 詳細ページにおいて、items&imagesテーブルから情報を取得し表示する